### PR TITLE
Fix to work with Multi-Run update.

### DIFF
--- a/IC_ShandieDashWait_Gui.ahk
+++ b/IC_ShandieDashWait_Gui.ahk
@@ -27,7 +27,7 @@ IC_ShandieDashWait_SettingsSave(){
     g_SF.WriteObjectToJSON( A_LineFile . "\..\DashWaitSettings.json" , g_ShandieDashWaitUserSettings )
     try ; avoid thrown errors when comobject is not available.
     {
-        local SharedRunData := ComObjActive("{416ABC15-9EFC-400C-8123-D7D8778A2103}")
+        local SharedRunData := ComObjActive(g_BrivFarm.GemFarmGUID)
         SharedRunData.ReloadShandieDashWaitSettings()
     }
     return


### PR DESCRIPTION
New update creates dynamic GUIDs for BrivGemFarm instead of using a static one. The generated GUID is stored in g_BrivFarm.GemFarmGUID. This fix handles this change.