### PR TITLE
Fixed conditional check.

### DIFF
--- a/IC_ShandieDashWait_Gui.ahk
+++ b/IC_ShandieDashWait_Gui.ahk
@@ -59,7 +59,7 @@ IC_ShandieDashWait_ReloadSettings()
     if ( g_ShandieDashWaitUserSettings["ShandieDashWaitPostStack"] == "" )
         g_ShandieDashWaitUserSettings["ShandieDashWaitPostStack"] := 1
     
-    if(g_ShandieDashWaitUserSettings["WriteSettings"] := true)
+    if(g_ShandieDashWaitUserSettings["WriteSettings"] == true)
     {
         g_ShandieDashWaitUserSettings.Delete("WriteSettings")
         g_SF.WriteObjectToJSON( A_LineFile . "\..\DashWaitSettings.json" , g_ShandieDashWaitUserSettings )   


### PR DESCRIPTION
I found this little bug lurking in the settings code in Script Hub and then saw it was also in this addon.

The conditional should be checking "if  variable == true" not  "if variable := true" as the latter is equivalent to "if true", which negates the need to have a conditional check and is always run when the function is called.