### PR TITLE
Fix to respect the AutoDetect setting.

### DIFF
--- a/IC_ShandieDashWait_Functions.ahk
+++ b/IC_ShandieDashWait_Functions.ahk
@@ -66,7 +66,7 @@ class IC_ShandieDashWait_SharedData_Class ;extends IC_SharedData_Class
         if ( g_ShandieDashWaitUserSettings["ShandieDashWaitPostStack"] == "" )
             g_ShandieDashWaitUserSettings["ShandieDashWaitPostStack"] := 1
         
-        if(g_ShandieDashWaitUserSettings["WriteSettings"] := true)
+        if(g_ShandieDashWaitUserSettings["WriteSettings"] == true)
         {
             g_ShandieDashWaitUserSettings.Delete("WriteSettings")
             g_SF.WriteObjectToJSON( A_LineFile . "\..\DashWaitSettings.json" , g_ShandieDashWaitUserSettings )   

--- a/IC_ShandieDashWait_Functions.ahk
+++ b/IC_ShandieDashWait_Functions.ahk
@@ -9,6 +9,7 @@ class IC_ShandieDashWait_SharedFunctions_Class extends IC_BrivSharedFunctions_Cl
         ShandieIsInFormation := this.IsChampInFormation( 47, this.Memory.GetCurrentFormation() )
         CurrentZone := this.Memory.ReadCurrentZone()
         Stacks := this.Memory.ReadSBStacks()
+        TargetStacks := g_BrivUserSettings[ "AutoCalculateBrivStacks" ] ? (g_BrivGemFarm.TargetStacks - g_BrivGemFarm.LeftoverStacks) : g_BrivUserSettings[ "TargetStacks" ]
         
 
         ; If no Shandie, just exit with false
@@ -35,7 +36,7 @@ class IC_ShandieDashWait_SharedFunctions_Class extends IC_BrivSharedFunctions_Cl
 
         ;MsgBox % "Stacks: " . Stacks . ", g_BrivUserSettings[ ""TargetStacks"" ]:" . g_BrivUserSettings[ "TargetStacks" ] . ", CurrentZone: " . CurrentZone . ", g_BrivUserSettings[ ""StackZone"" ]: " . g_BrivUserSettings[ "StackZone" ] . ", DashWaitPostStack: " . g_ShandieDashWaitUserSettings["ShandieDashWaitPostStack"]
         ; Then we check for Dash Wait post stack
-        if ( stacks > g_BrivUserSettings[ "TargetStacks" ] AND CurrentZone >= g_BrivUserSettings[ "StackZone" ] AND g_ShandieDashWaitUserSettings["ShandieDashWaitPostStack"]) {
+        if ( Stacks > TargetStacks AND CurrentZone >= g_BrivUserSettings[ "StackZone" ] AND g_ShandieDashWaitUserSettings["ShandieDashWaitPostStack"]) {
             ;MsgBox "Post Stack Dash Wait"
             return true
         }


### PR DESCRIPTION
This fix allows the check for stacks after stacking to use the ``AutoDetect`` setting when it is enabled. Previously stacks were being compared against the ``Target Haste stacks`` even though ``AutoDetect`` does not use that value.

Also corrected the conditional check for write settings in the addon's reload settings method used by the Gem Farm Script.